### PR TITLE
Replace simpleparse with pyparsing

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,12 +2,12 @@ Source: configshell
 Section: python
 Priority: optional
 Maintainer: Jerome Martin <jxm@risingtidesystems.com>
-Build-Depends: debhelper(>= 7.0.1), python2.6, python-epydoc, python-simpleparse
+Build-Depends: debhelper(>= 7.0.1), python2.6
 Standards-Version: 3.8.1
 
 Package: python-configshell
 Architecture: all
-Depends: python (>= 2.6)|python2.6, python-epydoc, python-simpleparse, python-urwid (>=0.9.9)
+Depends: python (>= 2.6)|python2.6, python-epydoc, python-pyparsing, python-urwid (>=0.9.9)
 Suggests: configshell-doc
 Description: Framework to create CLI interfaces.
  .

--- a/rpm/python-configshell.spec.tmpl
+++ b/rpm/python-configshell.spec.tmpl
@@ -10,8 +10,8 @@ URL:            http://www.risingtidesystems.com/git/
 Source:         %{oname}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-rpmroot
 BuildArch:      noarch
-BuildRequires:  python-devel, epydoc, python-simpleparse
-Requires:       python-simpleparse, python-urwid >= 0.9.9, epydoc
+BuildRequires:  python-devel
+Requires:       pyparsing, python-urwid >= 0.9.9, epydoc
 Vendor:         Datera, Inc.
 
 %description


### PR DESCRIPTION
Configshell uses simpleparse to parse the command line. Unfortunately,
simpleparse does not seem to be maintained anymore: the last release
was three years ago. Moreover, simpleparse is not widely used (on
Debian, only configshell depends on it).

On the other hand, pyparsing is actively maintained, widely used and
ready for Python 3. So let's use it.

Signed-off-by: Christophe Vu-Brugier cvubrugier@yahoo.fr
