### PR TITLE
2to3: preparatory work for python 3

### DIFF
--- a/configshell/node.py
+++ b/configshell/node.py
@@ -450,7 +450,7 @@ class ConfigNode(object):
         else:
             try:
                 value = type_method(ui_value)
-            except ValueError, msg:
+            except ValueError as msg:
                 raise ExecutionError(msg)
             else:
                 return value
@@ -509,7 +509,7 @@ class ConfigNode(object):
                     if p_def['writable']:
                         try:
                             value = type_method(value)
-                        except ValueError, msg:
+                        except ValueError as msg:
                             self.shell.log.error("Not setting %s! %s"
                                                  % (param, msg))
                         else:
@@ -698,7 +698,7 @@ class ConfigNode(object):
         '''
         try:
             target = self.get_node(path)
-        except ValueError, msg:
+        except ValueError as msg:
             self.shell.log.error(msg)
             return
 
@@ -1035,7 +1035,7 @@ class ConfigNode(object):
         # Normal path
         try:
             target_node = self.get_node(path)
-        except ValueError, msg:
+        except ValueError as msg:
             self.shell.log.error(msg)
             return None
         else:
@@ -1097,7 +1097,7 @@ class ConfigNode(object):
         loop = urwid.MainLoop(frame, palette, input_filter=handle_input)
         try:
             loop.run()
-        except Selected, pos:
+        except Selected as pos:
             return int(str(pos))
 
     def ui_complete_cd(self, parameters, text, current_param):
@@ -1415,7 +1415,7 @@ class ConfigNode(object):
         try:
             self.assert_params(method, pparams, kparams)
             result = method(*pparams, **kparams)
-        except ExecutionError, msg:
+        except ExecutionError as msg:
             self.shell.log.error(msg)
         else:
             return result

--- a/configshell/shell.py
+++ b/configshell/shell.py
@@ -821,7 +821,7 @@ class ConfigShell(object):
             if self._save_history:
                 try:
                     readline.write_history_file(self._cmd_history)
-                except IOError, msg:
+                except IOError as msg:
                     self.log.warning(
                         "Cannot write to command history file %s." \
                         % self._cmd_history)
@@ -895,7 +895,7 @@ class ConfigShell(object):
 
         try:
             target = self._current_node.get_node(path)
-        except ValueError, msg:
+        except ValueError as msg:
             self.log.error(msg)
         else:
             result = None
@@ -945,7 +945,7 @@ class ConfigShell(object):
         try:
             script_fd = open(script_path, 'r')
             self.run_stdin(script_fd, exit_on_error)
-        except IOError, msg:
+        except IOError as msg:
             raise IOError(msg)
         finally:
             script_fd.close()
@@ -963,7 +963,7 @@ class ConfigShell(object):
         for cmdline in file_descriptor:
             try:
                 self.run_cmdline(cmdline)
-            except Exception, msg:
+            except Exception as msg:
                 self.log.error(msg)
                 if exit_on_error is True:
                     self.log.exception("Aborting run on error.")


### PR DESCRIPTION
This patch for configshell-fb intend to ease compatibility with Python 3.

I ran `2to3` and selected the only fix named _except_ that we can apply right now because it is compatible with Python 2.7.

I did not apply the other fixes because I think they will break compatibility with Python 2.7. For configshell-fb, these fixes are:
- basestring
- dict
- import
- imports
- raw_input
- unicode
- xrange
- zip
