### PR TITLE
fix version in package builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME = configshell
 GIT_BRANCH = $$(git branch | grep \* | tr -d \*)
-VERSION = $$(basename $$(git describe --tags | tr - .))
+VERSION = $$(basename $$(git describe --tags | tr - . | sed 's/^v//'))
 
 all:
 	@echo "Usage:"
@@ -52,7 +52,7 @@ build/release-stamp:
 		rm -r rpm
 	@echo "Generating rpm changelog..."
 	@( \
-		version=$$(basename $$(git describe HEAD --tags | tr - .)); \
+		version=${VERSION}; \
 		author=$$(git show HEAD --format="format:%an <%ae>" -s); \
 		date=$$(git show HEAD --format="format:%ad" -s \
 			| awk '{print $$1,$$2,$$3,$$5}'); \
@@ -62,7 +62,7 @@ build/release-stamp:
 	) >> $$(ls build/${NAME}-${VERSION}/*.spec)
 	@echo "Generating debian changelog..."
 	@( \
-		version=$$(basename $$(git describe HEAD --tags | tr - .)); \
+		version=${VERSION}; \
 		author=$$(git show HEAD --format="format:%an <%ae>" -s); \
 		date=$$(git show HEAD --format="format:%aD" -s); \
 		day=$$(git show HEAD --format='format:%ai' -s \


### PR DESCRIPTION
Without this fix at least dpkg complains about the version
not starting with a number (starting with "v").

This should fix #7.
