### PR TITLE
Fix an integer division on Python 3

### DIFF
--- a/configshell/shell.py
+++ b/configshell/shell.py
@@ -742,7 +742,7 @@ class ConfigShell(object):
         prompt_length = self.prefs['prompt_length']
 
         if prompt_length and prompt_length < len(prompt_path):
-            half = (prompt_length-3)/2
+            half = (prompt_length - 3) // 2
             prompt_path = "%s...%s" \
                     % (prompt_path[:half], prompt_path[-half:])
 


### PR DESCRIPTION
With Python 2, '/' returns the floor of the mathematical result of
division if the arguments are ints. With Python 3, the operator
returns a reasonable approximation of the mathematical result of the
division.

This commit uses '//', which is the floor division operator in both
Python 2 and Python 3, so that the result can be safely used to index
an array.

For more details, see PEP 238 "changing the division operator"

  http://www.python.org/dev/peps/pep-0238

Signed-off-by: Christophe Vu-Brugier cvubrugier@yahoo.fr
