### PR TITLE
Fix ui_command_get() when no parameter is provided

### DIFF
--- a/configshell/node.py
+++ b/configshell/node.py
@@ -607,12 +607,12 @@ class ConfigNode(object):
                 value = group_getter(p_def['name'])
                 type_method = self.get_type_method(p_def['type'])
                 value = type_method(value, reverse=True)
-                parameter = "%s=%s" % (p_def['name'], value)
+                param = "%s=%s" % (p_def['name'], value)
                 if p_def['writable'] is False:
-                    parameter += " [ro]"
-                underline2 = ''.ljust(len(parameter), '-')
+                    param += " [ro]"
+                underline2 = ''.ljust(len(param), '-')
                 parameters += '%s\n%s\n%s\n\n' \
-                        % (parameter, underline2, p_def['description'])
+                        % (param, underline2, p_def['description'])
 
             self.shell.con.epy_write('''%s\n%s\n%s\n'''
                                      % (section, underline1, parameters))


### PR DESCRIPTION
The "get attribute" command displays an error message after the list
of attributes. For instance, in the TPG context, the following error
is displayed:

  No parameter 't' in group 'attribute'

This happens because the 'parameter' argument in ui_command_get() is
overwritten in the loop that iterates over the list of parameters to
display their value. This patch fixes the issue by renaming the
variable in the loop so that the value of the original 'parameter'
variable is preserved.

Signed-off-by: Christophe Vu-Brugier cvubrugier@yahoo.fr
