### PR TITLE
Fix import warning

### DIFF
--- a/examples/myshell
+++ b/examples/myshell
@@ -17,7 +17,7 @@ under the License.
 '''
 
 import os
-import configshell
+import configshell_fb as configshell
 
 class MySystemRoot(configshell.node.ConfigNode):
     def __init__(self, shell):


### PR DESCRIPTION
[ykaul@ykaul examples]$ ./myshell
./myshell:20: UserWarning: 'configshell' package name for configshell-fb is deprecated, please instead import 'configshell_fb'
  import configshell

Instead, importing configshell_fb as configshell