### PR TITLE
Fix the readline not defined error

### DIFF
--- a/configshell/shell.py
+++ b/configshell/shell.py
@@ -48,7 +48,17 @@ if sys.stdout.isatty():
     tty=True
 else:
     tty=False
+    
+    # remember the original setting
+    oldTerm = os.environ['TERM']
+    os.environ['TERM'] = ''
 
+    import readline
+
+    # restore the orignal TERM setting
+    os.environ['TERM'] = oldTerm
+    del oldTerm
+    
 # Pyparsing helper to group the location of a token and its value
 # http://stackoverflow.com/questions/18706631/pyparsing-get-token-location-in-results-name
 locator = Empty().setParseAction(lambda s, l, t: l)


### PR DESCRIPTION
TargetCLI will throw "readline not defined" error when running
it as process in interactive shell mode. The cause of the problem
is the readline module would not be imported in this case.
Set the TERM to empty is to fix readline emits unwanted characters
problem when import it.

Signed-off-by: Chongshi Zhang <zhangcho@us.ibm.com>