### PR TITLE
Add lock mechanism to make targetCLI thread safe

### DIFF
--- a/configshell/node.py
+++ b/configshell/node.py
@@ -1403,7 +1403,15 @@ class ConfigNode(object):
             raise ExecutionError("Command not found %s" % command)
 
         self.assert_params(method, pparams, kparams)
-        return method(*pparams, **kparams)
+        
+        try:
+            self.shell.lock.acquire()
+            return method(*pparams, **kparams)
+        finally:
+            if command  == 'exit':
+                self.shell.lock.exit()
+            else:
+                self.shell.lock.release()
 
     def assert_params(self, method, pparams, kparams):
         '''


### PR DESCRIPTION
When multiple targetCLI run at the same time and make changes to
configFS, that could cause corrupted configFS. So adding a cross
process locking mechanism can prevent targetCLI commands to run
currently, and solve this problem.

Signed-off-by: Chongshi Zhang <zhangcho@us.ibm.com>