### PR TITLE
Fix failing to pasre par=val parameters

### DIFF
--- a/configshell/shell.py
+++ b/configshell/shell.py
@@ -118,7 +118,7 @@ class ConfigShell(object):
 
         # Grammar of the command line
         command = locatedExpr(Word(alphanums + '_'))('command')
-        var = Word(alphanums + '_\+/.<>()~@:-%[]')
+        var = Word(alphanums + '=_\+/.<>()~@:-%[]')
         value = var
         keyword = Word(alphanums + '_\-')
         kparam = locatedExpr(keyword + Suppress('=') + Optional(value, default=''))('kparams*')


### PR DESCRIPTION
Through targetcli-fb to create LIO ceph target device like:
/backstores/user:rbd> create block0 10G pool/rbd1/osd_op_timeout=30
the =30 will be ignored.

Signed-off-by: Xiubo Li <lixiubo@cmss.chinamobile.com>