### PR TITLE
Remove explicit dependency on /usr/bin/python

### DIFF
--- a/examples/myshell
+++ b/examples/myshell
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 '''
 This file is part of ConfigShell.
 Copyright (c) 2011-2013 by Datera, Inc


### PR DESCRIPTION
The example script specifies /usr/bin/python, but
the code can all handle python2 or python2, so update
the script to work with either.

Note: this replaces a SPEC-file dependency on /usr/bin/python
with one on /usr/bin/env.