### PR TITLE
Acquire a lock to a preference file before working with it

### DIFF
--- a/configshell/prefs.py
+++ b/configshell/prefs.py
@@ -16,6 +16,7 @@ under the License.
 '''
 
 import six
+import fcntl
 
 class Prefs(object):
     '''
@@ -128,6 +129,7 @@ class Prefs(object):
 
         if filename is not None:
             fsock = open(filename, 'wb')
+            fcntl.lockf(fsock, fcntl.LOCK_UN)
             try:
                 six.moves.cPickle.dump(self._prefs, fsock, 2)
             finally:
@@ -143,6 +145,7 @@ class Prefs(object):
 
         if filename is not None:
             fsock = open(filename, 'rb')
+            fcntl.lockf(fsock, fcntl.LOCK_SH)
             try:
                 self._prefs = six.moves.cPickle.load(fsock)
             finally:


### PR DESCRIPTION
Otherwise we can meet a situation, when one process is writing a file,
but another process tries to read the same file:

prefs.py:147:load:EOFError

Traceback (most recent call last):
  File "/usr/bin/targetcli", line 121, in <module>
    main()
  File "/usr/bin/targetcli", line 77, in main
    shell = TargetCLI('~/.targetcli')
  File "/usr/lib/python2.7/site-packages/configshell_fb/shell.py", line 176, in __init__
    self.prefs.load()
  File "/usr/lib/python2.7/site-packages/configshell_fb/prefs.py", line 147, in load
    self._prefs = six.moves.cPickle.load(fsock)
EOFError

Local variables in innermost frame:
self: <configshell_fb.prefs.Prefs object at 0x1077550>
fsock: <closed file '/root/.targetcli/prefs.bin', mode 'rb' at 0x1058300>
filename: '/root/.targetcli/prefs.bin'