### PR TITLE
Fix failing to parse param like pool/rbd;id=user

### DIFF
--- a/configshell/shell.py
+++ b/configshell/shell.py
@@ -118,7 +118,7 @@ class ConfigShell(object):
 
         # Grammar of the command line
         command = locatedExpr(Word(alphanums + '_'))('command')
-        var = Word(alphanums + ',=_\+/.<>()~@:-%[]')
+        var = Word(alphanums + ';,=_\+/.<>()~@:-%[]')
         value = var
         keyword = Word(alphanums + '_\-')
         kparam = locatedExpr(keyword + Suppress('=') + Optional(value, default=''))('kparams*')


### PR DESCRIPTION
Fixes trying to create an lio ceph device with the optional args:
    /backstores/user:rbd/ create name 1M pool/device;id=user