### PR TITLE
Fix failing to parse params with additional chars

### DIFF
--- a/configshell/shell.py
+++ b/configshell/shell.py
@@ -118,7 +118,7 @@ class ConfigShell(object):
 
         # Grammar of the command line
         command = locatedExpr(Word(alphanums + '_'))('command')
-        var = Word(alphanums + ';,=_\+/.<>()~@:-%[]')
+        var = Word(alphanums + '?;&*$!#,=_\+/.<>()~@:-%[]')
         value = var
         keyword = Word(alphanums + '_\-')
         kparam = locatedExpr(keyword + Suppress('=') + Optional(value, default=''))('kparams*')


### PR DESCRIPTION
Example: cfgstring=sas-?st=2018-08-24T15%3A21%3A22Z&se=
2018-08-25T15%3A21%3A22Z&sp=rwl&sv=2018-03-28&sr=b&sig= ....

contains a number of characters that are not correctly parsed, causing
the cfgstring to be truncated

Signed-off-by: Maurizio Lombardi <mlombard@redhat.com>