### PR TITLE
Add urwid to setup.py dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
     install_requires = [
         'pyparsing',
         'six',
+        'urwid',
     ],
     classifiers = [
         "Programming Language :: Python",


### PR DESCRIPTION
It's required in configshell/node.py and crashes when reaching the
function that imports it.