### PR TITLE
Ensure that all output reaches the client when daemonized

### DIFF
--- a/configshell/console.py
+++ b/configshell/console.py
@@ -191,7 +191,7 @@ class Console(object):
                 break
         else:
             clean_text = text
-        self.raw_write(clean_text)
+        self.raw_write(clean_text, output=self._stdout)
 
     def indent(self, text, margin=2):
         '''


### PR DESCRIPTION
Any commands that use `epy_write` are currently writing to sys.stdout, so their output hits the systemd journal when daemonized. This commit ensures that the correct "stdout" is used, which ensures that the output is sent over the socket to `targetcli`.