### PR TITLE
Don't warn if prefs file doesn't exist

### DIFF
--- a/configshell/prefs.py
+++ b/configshell/prefs.py
@@ -15,6 +15,7 @@ License for the specific language governing permissions and limitations
 under the License.
 '''
 
+import os
 import six
 import fcntl
 
@@ -143,7 +144,7 @@ class Prefs(object):
         if filename is None:
             filename = self.filename
 
-        if filename is not None:
+        if filename is not None and os.path.exists(filename):
             fsock = open(filename, 'rb')
             fcntl.lockf(fsock, fcntl.LOCK_SH)
             try:


### PR DESCRIPTION
The first time configshell is used, prefs.bin won't exist, so you'll see something like:

Warning: Could not load preferences file /root/.whatever/prefs.bin.

If the file doesn't actually exist, this warning is just confusing, so I've added an existence check to Prefs.load()

Signed-off-by: Tim Serong <tserong@suse.com>