### PR TITLE
setup.py: lets stick to pyparsing v2.4.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     url = 'http://github.com/open-iscsi/configshell-fb',
     packages = ['configshell', 'configshell_fb'],
     install_requires = [
-        'pyparsing >= 2.0.2',
+        'pyparsing == 2.4.7',
         'six',
         'urwid',
     ],


### PR DESCRIPTION
Currently setup.py is pulling pyparsing-3.0.0a1 which is a pre-release candidate,
and is even failing to build.

Since pyparsing is failing to build, configshell build is inturn failing.

May be for now, lets stick to the stable release pyparsing-2.4.7

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>