### PR TITLE
setup.py: specify a version range for pyparsing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     url = 'http://github.com/open-iscsi/configshell-fb',
     packages = ['configshell', 'configshell_fb'],
     install_requires = [
-        'pyparsing == 2.4.7',
+        'pyparsing >=2.0.2,<3.0',
         'six',
         'urwid',
     ],


### PR DESCRIPTION
Instead of locking to a specific version, this specifies the earliest
version that it should use and which versions it should not use.

This allows the package spec files to apply to a wider range of
distributions.