### PR TITLE
ConfigShell support passing Console object as parameter

### DIFF
--- a/configshell/shell.py
+++ b/configshell/shell.py
@@ -101,7 +101,7 @@ class ConfigShell(object):
     _current_token = ''
     _current_completions = []
 
-    def __init__(self, preferences_dir=None):
+    def __init__(self, preferences_dir=None, console=None):
         '''
         Creates a new ConfigShell.
         @param preferences_dir: Directory to load/save preferences from/to
@@ -177,7 +177,9 @@ class ConfigShell(object):
             if pref not in self.prefs:
                 self.prefs[pref] = value
 
-        self.con = console.Console()
+        if console is None:
+            console = console.Console()
+        self.con = console
 
     # Private methods
 


### PR DESCRIPTION
Setting preference maybe rollback when execute multiple targetcli requests concurrently.
Please see https://github.com/open-iscsi/targetcli-fb/issues/188 for details.
In order to solve this problem we must first initialize a Console object.

Signed-off-by: Zou Mingzhe <mingzhe.zou@easystack.cn>