### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ init_file_path = os.path.join(os.path.dirname(__file__), 'configshell/__init__.p
 with open(init_file_path) as f:
     for line in f:
         match = re.match(r"__version__.*'([0-9.]+)'", line)
+        match = re.match(r"__version__.*'([0-9]+\.[0-9]+\.[0-9]+.*\.[a-z].*)'", line)
         if match:
             version = match.group(1)
             break


### PR DESCRIPTION
Testing on a RHEL 6.10 derivative using Python 2.6.6, that re.match didn't result in a version being detected.  This fix extracted the correct version.   Appears same change would be needed in rtslib-fb and targetcli-fb as well I believe.  Don't have an opportunity to try this on a RHEL 7 though so not 100% if this would cover that version.