### PR TITLE
setup.py: relax pyparsing version restriction

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     url = 'http://github.com/open-iscsi/configshell-fb',
     packages = ['configshell', 'configshell_fb'],
     install_requires = [
-        'pyparsing >=2.0.2,<3.0',
+        'pyparsing >=2.0.2',
         'six',
         'urwid',
     ],


### PR DESCRIPTION
The need to restrict pyparsing to <3.0 seems to be unnecessary anymore. It is from the time when pyparsing-3 was pre-release candidate which was causing build failures. Original commit [1] locked pyparsing on specific version which was later relaxed to <3.0 [2]. pyparsing is currently in version 3.0.9 and it works fine with configshell-fb.

[1] ec7ca0ee13a2 ("setup.py: lets stick to pyparsing v2.4.7")
[2] f1fd5a920760 ("setup.py: specify a version range for pyparsing")