### PR TITLE
Remove usage of six

### DIFF
--- a/configshell/console.py
+++ b/configshell/console.py
@@ -17,7 +17,6 @@ under the License.
 
 from fcntl import ioctl
 import re
-import six
 import struct
 import sys
 from termios import TIOCGWINSZ, TCSADRAIN, tcsetattr, tcgetattr

--- a/configshell/node.py
+++ b/configshell/node.py
@@ -17,7 +17,6 @@ under the License.
 
 import inspect
 import re
-import six
 
 class ExecutionError(Exception):
     pass
@@ -503,7 +502,7 @@ class ConfigNode(object):
         elif group not in self.list_config_groups():
             raise ExecutionError("Unknown configuration group: %s" % group)
 
-        for param, value in six.iteritems(parameter):
+        for param, value in parameter.items():
             if param not in self.list_group_params(group):
                 raise ExecutionError("Unknown parameter %s in group '%s'."
                                      % (param, group))
@@ -1256,7 +1255,7 @@ class ConfigNode(object):
                 bookmarks += "No bookmarks yet.\n"
             else:
                 for (bookmark, path) \
-                        in six.iteritems(self.shell.prefs['bookmarks']):
+                        in self.shell.prefs['bookmarks'].items():
                     if len(bookmark) == 1:
                         bookmark += '\0'
                     underline = ''.ljust(len(bookmark), '-')
@@ -1703,7 +1702,7 @@ class ConfigNode(object):
             return []
         else:
             params = []
-            for p_name, p_def in six.iteritems(self._configuration_groups[group]):
+            for p_name, p_def in self._configuration_groups[group].items():
                 (p_type, p_description, p_writable) = p_def
                 if writable is not None and p_writable != writable:
                     continue

--- a/configshell/prefs.py
+++ b/configshell/prefs.py
@@ -16,8 +16,8 @@ under the License.
 '''
 
 import os
-import six
 import fcntl
+import pickle
 
 class Prefs(object):
     '''
@@ -116,7 +116,7 @@ class Prefs(object):
         @return: Iterates on the items in preferences.
         @rtype: yields items that are (key, value) pairs
         '''
-        return six.iteritems(self._prefs)
+        return self._prefs.items()
 
     def save(self, filename=None):
         '''
@@ -132,7 +132,7 @@ class Prefs(object):
             fsock = open(filename, 'wb')
             fcntl.lockf(fsock, fcntl.LOCK_UN)
             try:
-                six.moves.cPickle.dump(self._prefs, fsock, 2)
+                pickle.dump(self._prefs, fsock, 2)
             finally:
                 fsock.close()
 
@@ -148,6 +148,6 @@ class Prefs(object):
             fsock = open(filename, 'rb')
             fcntl.lockf(fsock, fcntl.LOCK_SH)
             try:
-                self._prefs = six.moves.cPickle.load(fsock)
+                self._prefs = pickle.load(fsock)
             finally:
                 fsock.close()

--- a/configshell/shell.py
+++ b/configshell/shell.py
@@ -16,7 +16,6 @@ under the License.
 '''
 
 import os
-import six
 import sys
 from pyparsing import (alphanums, Empty, Group, locatedExpr,
                        OneOrMore, Optional, ParseResults, Regex,
@@ -173,7 +172,7 @@ class ConfigShell(object):
             self.log.warning("Could not load preferences file %s."
                              % self._prefs_file)
 
-        for pref, value in six.iteritems(self.default_prefs):
+        for pref, value in self.default_prefs.items():
             if pref not in self.prefs:
                 self.prefs[pref] = value
 
@@ -239,7 +238,7 @@ class ConfigShell(object):
             else:
                 nr_cols = 1
 
-            for i in six.moves.range(0, len(matches), nr_cols):
+            for i in range(0, len(matches), nr_cols):
                 self.con.raw_write(''.join(matches[i:i+nr_cols]))
                 self.con.raw_write('\n')
 
@@ -402,7 +401,7 @@ class ConfigShell(object):
         for index in range(len(pparams)):
             if index < len(cmd_params):
                 current_parameters[cmd_params[index]] = pparams[index]
-        for key, value in six.iteritems(kparams):
+        for key, value in kparams.items():
             current_parameters[key] = value
         self._completion_help_topic = command
         completion_method = target.get_completion_method(command)
@@ -550,7 +549,7 @@ class ConfigShell(object):
         current_parameters = {}
         for index in range(len(pparams)):
             current_parameters[cmd_params[index]] = pparams[index]
-        for key, value in six.iteritems(kparams):
+        for key, value in kparams.items():
             current_parameters[key] = value
         completion_method = target.get_completion_method(command)
         if completion_method:
@@ -722,7 +721,7 @@ class ConfigShell(object):
             try:
                 readline.parse_and_bind("tab: complete")
                 readline.set_completer(self._complete)
-                cmdline = six.moves.input(self._get_prompt()).strip()
+                cmdline = input(self._get_prompt()).strip()
             except EOFError:
                 self.con.raw_write('exit\n')
                 cmdline = "exit"

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setup(
     packages = ['configshell', 'configshell_fb'],
     install_requires = [
         'pyparsing >=2.0.2',
-        'six',
         'urwid',
     ],
     classifiers = [


### PR DESCRIPTION
Since the library is now Python 3.x only, let's remove the unneeded compatibility layer.