### PR TITLE
Fix help messages without a trailing newline

### DIFF
--- a/configshell/node.py
+++ b/configshell/node.py
@@ -481,7 +481,7 @@ class ConfigNode(object):
             self.shell.con.epy_write('''
                                      AVAILABLE CONFIGURATION GROUPS
                                      ==============================
-                                     %s
+                                     %s\n
                                      ''' % ' '.join(self.list_config_groups()))
         elif not parameter:
             if group not in self.list_config_groups():
@@ -589,7 +589,7 @@ class ConfigNode(object):
             self.shell.con.epy_write('''
                                      AVAILABLE CONFIGURATION GROUPS
                                      ==============================
-                                     %s
+                                     %s\n
                                      ''' % ' '.join(self.list_config_groups()))
         elif not parameter:
             if group not in self.list_config_groups():
@@ -1125,6 +1125,7 @@ class ConfigNode(object):
                                    ''')
             for command in commands:
                 msg += "  - %s\n" % self.get_command_syntax(command)[0]
+            msg += "\n"
             self.shell.con.epy_write(msg)
             return
 


### PR DESCRIPTION
A few of the help messages leave of a trailing newline, which results in the help message and the prompt for the next command running together, such as:

	/iscsi/iqn.20...6021425c/tpg1> get

	AVAILABLE CONFIGURATION GROUPS
	==============================
	global parameter attribute auth/iscsi/iqn.20...6021425c/tpg1>

Fix this by adding a newline, where needed.