### PR TITLE
Adding -fb suffix to module name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ build-backend = "hatchling.build"
 requires = ["hatchling", "hatch-vcs"]
 
 [project]
-name = "configshell"
+name = "configshell-fb"
 description = "A framework to implement simple but nice CLIs."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
PyPI does not allow 'configshell' name, falling back.