### PR TITLE
Add backwards compatibility with _fb module name

### DIFF
--- a/configshell_fb.py
+++ b/configshell_fb.py
@@ -1,0 +1,12 @@
+# Providing backwards compatibility for modules importing 'configshell_fb'
+
+from configshell import Console, Log, ConfigNode, ExecutionError, Prefs, ConfigShell
+
+__all__ = [
+    'Console',
+    'Log',
+    'ConfigNode',
+    'ExecutionError',
+    'Prefs',
+    'ConfigShell',
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,10 @@ Homepage = "http://github.com/open-iscsi/configshell-fb"
 source = "vcs"
 
 [tool.hatch.build.targets.wheel]
-packages = ["configshell"]
+packages = [
+    "configshell",
+    "configshell_fb.py"
+]
 
 [tool.hatch.envs.default]
 dependencies = [


### PR DESCRIPTION
Thought about printing deprecation warning, but probably not worth it at the moment