### PR TITLE
Add pypi publish and pre-commit workflows

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,14 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+    - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+name: pypi-release
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch, tag or SHA to checkout'
+        required: true
+        default: 'master'
+
+jobs:
+  pypi-publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write  # Needed for trusted publishing
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/configshell-fb
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Build a binary wheel and a source tarball
+        run: |
+            python -m pip install hatch
+            hatch build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.4.4
+    rev: v0.6.4
     hooks:
       - id: ruff
         args: [--fix]

--- a/configshell_fb.py
+++ b/configshell_fb.py
@@ -1,6 +1,6 @@
 # Providing backwards compatibility for modules importing 'configshell_fb'
 
-from configshell import Console, Log, ConfigNode, ExecutionError, Prefs, ConfigShell
+from configshell import ConfigNode, ConfigShell, Console, ExecutionError, Log, Prefs
 
 __all__ = [
     'Console',


### PR DESCRIPTION
Using the recommended[Trusted Publishers](https://docs.pypi.org/trusted-publishers/) to build and publish package to PyPA.

@maurizio-lombardi 'environment' is `pypi`, yaml is `.github/workflows/publish.yml`