### PR TITLE
Fix new ruff/pre-commit errors

### DIFF
--- a/configshell/node.py
+++ b/configshell/node.py
@@ -1243,12 +1243,12 @@ class ConfigNode:
             if not self.shell.prefs['bookmarks']:
                 bookmarks += "No bookmarks yet.\n"
             else:
-                for (bookmark, path) \
+                for (b, path) \
                         in self.shell.prefs['bookmarks'].items():
-                    if len(bookmark) == 1:
+                    if len(b) == 1:
                         bookmark += '\0'
-                    underline = ''.ljust(len(bookmark), '-')
-                    bookmarks += f"{bookmark}\n{underline}\n{path}\n\n"
+                    underline = ''.ljust(len(b), '-')
+                    bookmarks += f"{b}\n{underline}\n{path}\n\n"
             self.shell.con.epy_write(bookmarks)
             return None
         else:

--- a/configshell/shell.py
+++ b/configshell/shell.py
@@ -405,8 +405,7 @@ class ConfigShell:
         for index in range(len(pparams)):
             if index < len(cmd_params):
                 current_parameters[cmd_params[index]] = pparams[index]
-        for key, value in kparams.items():
-            current_parameters[key] = value
+        current_parameters.update(kparams)
         self._completion_help_topic = command
         completion_method = target.get_completion_method(command)
         self.log.debug(f"Command {command} accepts parameters {cmd_params}.")
@@ -547,8 +546,7 @@ class ConfigShell:
         current_parameters = {}
         for index in range(len(pparams)):
             current_parameters[cmd_params[index]] = pparams[index]
-        for key, value in kparams.items():
-            current_parameters[key] = value
+        current_parameters.update(kparams)
         completion_method = target.get_completion_method(command)
         if completion_method:
             completions = completion_method(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,3 +98,5 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 # Possible hardcoded password assigned to: "current_token"
 "configshell/shell" = ["S105"]
+# Required for pre-commit. Examples could be improved though.
+"examples/*" = ["S"]


### PR DESCRIPTION
pre-commit action is using all files as an input, this includes `examples` directory, even though it is not `.py` file. Disabling flake8-bandit checks there.  
Resolving issues found by new ruff version - use dict comprehension, do not rewrite 'bookmark' variable.